### PR TITLE
Correct spelling

### DIFF
--- a/hyperiax/tree/builders.py
+++ b/hyperiax/tree/builders.py
@@ -16,7 +16,7 @@ def THeight_legacy(h,degree,new_node=TreeNode,fake_root=None):
 
 
 
-def assymetric_tree(h):
+def asymmetric_tree(h):
     """ generative tree of given height """
     if h ==1:
         return HypTree(TreeNode())


### PR DESCRIPTION
Rename the method

When merging, please remember to also
- rename the method in the `Tree building.ipynb` example (preferably do this _after_ merging the other PR involving that file, as I think merge conflicts in notebooks are somewhat nasty),
- update the name in the [wiki page](https://github.com/ComputationalEvolutionaryMorphometry/hyperiax/wiki/Getting-Started)